### PR TITLE
Fix: wheel builds

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev libkrb5-dev clang
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev libkrb5-dev clang
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev libkrb5-dev
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev libkrb5-dev
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev libkrb5-dev libclang-dev
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev clang
+          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev clang-devel
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python
@@ -181,7 +181,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev clang
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev clang-devel
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66
+          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev clang
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python
@@ -181,7 +181,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev clang
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev clang-devel 
+          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev 
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev clang-devel
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev 
+          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev libclang-dev
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python
@@ -181,7 +181,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev
+          apt-get install -y curl postgresql-client build-essential python3-dev python3-pip pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client libmysqlclient-dev python3 python3-pip libicu66 libkrb5-dev libclang-dev
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           apt-get update
-          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev clang-devel
+          apt-get install -y curl postgresql-client build-essential pkg-config libssl-dev git sqlite3 libsqlite3-dev mysql-client python3 python3-pip libicu66 libkrb5-dev clang-devel 
           pip3 install mssql-cli
           pip3 install cli-helpers==2.2.0
           ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install epel-release
+          yum install -y epel-release
           yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
 
       - name: Setup project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Install tools
         run: |
+          yum install epel-release
           yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
 
       - name: Setup project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,9 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml -i python --release
         env:
           SQLITE3_STATIC: 1
 
@@ -133,9 +133,9 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml -i python --release
         env:
           SQLITE3_STATIC: 1
 
@@ -180,9 +180,9 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
         env:
           SQLITE3_STATIC: 1
 
@@ -194,9 +194,9 @@ jobs:
       - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --no-sdist --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
         env:
           SQLITE3_STATIC: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,9 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7 centos-release-scl
-          scl enable llvm-toolset-7 'bash'
-          uname -a
-          cat /etc/*release
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7
+          #really unsure why installing llvm doesn't work. Maybe this will
+          pip install libclang
           clang --version
 
       - name: Setup project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,12 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7 centos-release-scl
           scl enable devtoolset-7 llvm-toolset-7 bash
           uname -a
           cat /etc/*release
+          clang --version
+          yum whatprovides *libclang.so
 
       - name: Setup project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7.0
+          yum install -y mysql-devel postgresql-devel freetds-devel
+          apt update
+          apt install libkrb5-dev clang
 
       - name: Setup project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7
+          scl enable devtoolset-7 llvm-toolset-7 bash
           uname -a
           cat /etc/*release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,10 @@ jobs:
       - name: Install tools
         run: |
           yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7 centos-release-scl
-          scl enable devtoolset-7 llvm-toolset-7 bash
+          scl enable llvm-toolset-7 'bash'
           uname -a
           cat /etc/*release
           clang --version
-          yum whatprovides *libclang.so
 
       - name: Setup project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs
 
       - name: Setup project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7.0
 
       - name: Setup project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
       matrix:
         python-version: [[38, "3.8"], [39, "3.9"], [310, "3.10"], [311, "3.11"]]
@@ -50,7 +50,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.12.1
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2014
+          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2_28
         env:
           SQLITE3_STATIC: 1
 
@@ -64,7 +64,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.12.1
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2014
+          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2_28
         env:
           SQLITE3_STATIC: 1
 
@@ -72,7 +72,7 @@ jobs:
       #   with:
       #     maturin-version: v0.12.1
       #     command: build
-      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --no-sdist --release --manylinux 2014
+      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --no-sdist --release --manylinux 2_28
       #   env:
       #     SQLITE3_STATIC: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel
-          apt update
-          apt install libkrb5-dev clang
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset
+          uname -a
+          cat /etc/*release
 
       - name: Setup project
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
         run: |
           just bootstrap-python
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2_28
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
         env:
           SQLITE3_STATIC: 1
 
@@ -60,20 +60,20 @@ jobs:
           cp -rf connectorx-python/target/release/jassets connectorx-python/connectorx/dependencies
 
       # rebuild the wheel to incorporate j4rs dependencies
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
-          maturin-version: v0.12.1
+          maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --no-sdist --release --manylinux 2_28
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
         env:
           SQLITE3_STATIC: 1
 
-      # - uses: messense/maturin-action@v1
+      # - uses: PyO3/maturin-action@v1
       #   with:
-      #     maturin-version: v0.12.1
+      #     maturin-version: v0.14.15
       #     command: build
-      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --no-sdist --release --manylinux 2_28
+      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28
       #   env:
       #     SQLITE3_STATIC: 1
 
@@ -116,7 +116,7 @@ jobs:
         run: |
           just bootstrap-python
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
           maturin-version: v0.12.1
@@ -130,7 +130,7 @@ jobs:
           cp -r connectorx-python/target/release/jassets connectorx-python/connectorx/dependencies
 
       # rebuild the wheel to incorporate j4rs dependencies
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
           maturin-version: v0.12.1
@@ -177,7 +177,7 @@ jobs:
         run: |
           just bootstrap-python
 
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
           maturin-version: v0.12.1
@@ -191,7 +191,7 @@ jobs:
           cp -rf connectorx-python/target/aarch64-apple-darwin/release/jassets connectorx-python/connectorx/dependencies
 
       # rebuild the wheel to incorporate j4rs dependencies
-      - uses: messense/maturin-action@v1
+      - uses: PyO3/maturin-action@v1
         with:
           rust-toolchain: 1.65.0
           maturin-version: v0.12.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,7 @@ jobs:
 
       - name: Set python version
         run: |
-          if [[ "${{ matrix.python-version[0] }}" == "37" ]]; then
-            echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-          else
-            echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
-          fi
+          echo "/opt/python/cp${{ matrix.python-version[0] }}-cp${{ matrix.python-version[0] }}/bin" >> $GITHUB_PATH
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,7 @@ jobs:
 
       - name: Install tools
         run: |
-          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs llvm-toolset-7 devtoolset-7
-          #really unsure why installing llvm doesn't work. Maybe this will
-          pip install libclang
-          clang --version
+          yum install -y mysql-devel postgresql-devel freetds-devel krb5-libs clang-devel
 
       - name: Setup project
         run: |

--- a/scripts/python-helper.py
+++ b/scripts/python-helper.py
@@ -61,7 +61,7 @@ def main() -> None:
             else:
                 abitag = pyver
         elif METADATA["platform"] == "linux":
-            arch = "manylinux2014_x86_64"
+            arch = "manylinux_2_28_x86_64"
             abitag = METADATA["abi_tag"]
         elif METADATA["platform"] == "darwin":
             arch = "macosx_10_15_intel"


### PR DESCRIPTION
This updates the `manylinux` version because `manylinux2014` only supports `clang@3.4.2` where `libgssapi` requires `clang>=3.9`. `manylinux_2_28` supports `clang@14` solving a lot of issues. This also updates `maturin` to fix a panic while auditing the built wheel. 

FWIW, `manylinux2014` is [EOL June 30th, 2024](https://github.com/pypa/manylinux#manylinux) so this change needs to happen soon anyway.