### PR TITLE
Fix/features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release ${ matrix.features }
+          args: -m connectorx-python/Cargo.toml -i python --release ${{ matrix.features }}
         env:
           SQLITE3_STATIC: 1
 
@@ -134,7 +134,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release ${ matrix.features }
+          args: -m connectorx-python/Cargo.toml -i python --release ${{ matrix.features }}
         env:
           SQLITE3_STATIC: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28 --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 
@@ -61,7 +61,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28
+          args: -m connectorx-python/Cargo.toml -i python --release --manylinux 2_28 --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 
@@ -69,7 +69,7 @@ jobs:
       #   with:
       #     maturin-version: v0.14.15
       #     command: build
-      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28
+      #     args: -m connectorx-python/Cargo.toml --target aarch64-unknown-linux-gnu -i python --release --manylinux 2_28 --features integrated-auth-gssapi
       #   env:
       #     SQLITE3_STATIC: 1
 
@@ -84,6 +84,9 @@ jobs:
       matrix:
         os: ["windows-latest", "macos-10.15"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        include:
+          - os: "macos-10.15"
+            features: "--features integrated-auth-gssapi"
     steps:
       - uses: actions/checkout@v2
 
@@ -117,7 +120,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release
+          args: -m connectorx-python/Cargo.toml -i python --release ${ matrix.features }
         env:
           SQLITE3_STATIC: 1
 
@@ -131,7 +134,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml -i python --release
+          args: -m connectorx-python/Cargo.toml -i python --release ${ matrix.features }
         env:
           SQLITE3_STATIC: 1
 
@@ -178,7 +181,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release  --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 
@@ -192,7 +195,7 @@ jobs:
           rust-toolchain: 1.65.0
           maturin-version: v0.14.15
           command: build
-          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release
+          args: -m connectorx-python/Cargo.toml --target aarch64-apple-darwin -i python --release  --features integrated-auth-gssapi
         env:
           SQLITE3_STATIC: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,6 @@ dependencies = [
  "iai",
  "itertools",
  "j4rs",
- "libgssapi",
  "log",
  "mysql_common",
  "native-tls",

--- a/connectorx-python/Cargo.toml
+++ b/connectorx-python/Cargo.toml
@@ -76,3 +76,4 @@ srcs = [
   "connectorx/src_oracle",
   "connectorx/src_bigquery",
 ]
+integrated-auth-gssapi = ["connectorx/integrated-auth-gssapi"]

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -78,7 +78,7 @@ fptr = []
 src_bigquery = ["gcp-bigquery-client", "tokio"]
 src_csv = ["csv", "regex"]
 src_dummy = ["num-traits"]
-src_mssql = ["rust_decimal", "num-traits", "tiberius", "tiberius/integrated-auth-gssapi", "bb8-tiberius", "bb8", "tokio", "tokio-util", "uuid", "futures", "urlencoding"]
+src_mssql = ["rust_decimal", "num-traits", "tiberius", "bb8-tiberius", "bb8", "tokio", "tokio-util", "uuid", "futures", "urlencoding"]
 src_mysql = ["r2d2_mysql", "mysql_common", "rust_decimal", "num-traits", "r2d2"]
 src_oracle = ["oracle", "r2d2-oracle","r2d2", "urlencoding"]
 src_postgres = [
@@ -99,6 +99,7 @@ src_postgres = [
 src_sqlite = ["rusqlite", "r2d2_sqlite", "fallible-streaming-iterator", "r2d2", "urlencoding"]
 federation = ["j4rs"]
 fed_exec = ["datafusion", "tokio"]
+integrated-auth-gssapi = ["tiberius/integrated-auth-gssapi"]
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/connectorx/Cargo.toml
+++ b/connectorx/Cargo.toml
@@ -58,9 +58,6 @@ uuid = {version = "0.8", optional = true}
 j4rs = {version = "0.13", optional = true}
 datafusion = {version = "14", optional = true}
 
-[target.'cfg(unix)'.dependencies]
-libgssapi = { version = "0.4.5", optional = true, default-features = false }
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 name = "connectorx"
@@ -72,7 +69,7 @@ iai = "0.1"
 pprof = {version = "0.5", features = ["flamegraph"]}
 
 [features]
-all = ["src_sqlite", "src_postgres", "src_mysql", "src_mssql", "src_oracle", "src_bigquery", "src_csv", "src_dummy", "dst_arrow", "dst_arrow2", "federation", "fed_exec", "integrated-auth-gssapi"]
+all = ["src_sqlite", "src_postgres", "src_mysql", "src_mssql", "src_oracle", "src_bigquery", "src_csv", "src_dummy", "dst_arrow", "dst_arrow2", "federation", "fed_exec"]
 branch = []
 default = ["fptr"]
 dst_arrow = ["arrow"]
@@ -81,7 +78,7 @@ fptr = []
 src_bigquery = ["gcp-bigquery-client", "tokio"]
 src_csv = ["csv", "regex"]
 src_dummy = ["num-traits"]
-src_mssql = ["rust_decimal", "num-traits", "tiberius", "bb8-tiberius", "bb8", "tokio", "tokio-util", "uuid", "futures", "urlencoding"]
+src_mssql = ["rust_decimal", "num-traits", "tiberius", "tiberius/integrated-auth-gssapi", "bb8-tiberius", "bb8", "tokio", "tokio-util", "uuid", "futures", "urlencoding"]
 src_mysql = ["r2d2_mysql", "mysql_common", "rust_decimal", "num-traits", "r2d2"]
 src_oracle = ["oracle", "r2d2-oracle","r2d2", "urlencoding"]
 src_postgres = [
@@ -102,6 +99,6 @@ src_postgres = [
 src_sqlite = ["rusqlite", "r2d2_sqlite", "fallible-streaming-iterator", "r2d2", "urlencoding"]
 federation = ["j4rs"]
 fed_exec = ["datafusion", "tokio"]
-integrated-auth-gssapi = ["libgssapi"]
+
 [package.metadata.docs.rs]
 features = ["all"]

--- a/connectorx/src/sources/mssql/mod.rs
+++ b/connectorx/src/sources/mssql/mod.rs
@@ -63,7 +63,6 @@ pub fn mssql_config(url: &Url) -> Config {
     // Using SQL Server authentication.
     #[allow(unused)]
     let params: HashMap<String, String> = url.query_pairs().into_owned().collect();
-    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
     match params.get("trusted_connection") {
         // pefer trusted_connection if set to true
         Some(v) if v == "true" => {
@@ -78,11 +77,6 @@ pub fn mssql_config(url: &Url) -> Config {
             ));
         }
     };
-    #[cfg(all(not(windows), not(feature = "integrated-auth-gssapi")))]
-    config.authentication(AuthMethod::sql_server(
-        decode(url.username())?.to_owned(),
-        decode(url.password().unwrap_or(""))?.to_owned(),
-    ));
 
     match params.get("encrypt") {
         Some(v) if v.to_lowercase() == "true" => config.encryption(EncryptionLevel::Required),


### PR DESCRIPTION
This creates the `integrated-auth-gssapi` feature in the `connectorx` and `connectorx-python` rust libraries. At the lowest level, it just enables the `tiberius/ntegrated-auth-gssapi` feature which uses the `libgssapi` library to handle integrated authentication for MSSQL servers. This also enables the feature for all Unix (and NOT Windows) based python wheels built in `.github/workflows/release.yml`.